### PR TITLE
[rush-archive-project-plugin] Create a git branch checkpoint when archiving a project

### DIFF
--- a/common/autoinstallers/command-plugins/package.json
+++ b/common/autoinstallers/command-plugins/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "rush-archive-project-plugin": "link:../../../rush-plugins/rush-archive-project-plugin",
+    "rush-archive-project-plugin": "1.1.3",
     "rush-audit-cache-plugin": "0.0.2",
     "rush-init-project-plugin": "0.6.0",
     "rush-lint-staged-plugin": "0.1.6",

--- a/common/autoinstallers/command-plugins/package.json
+++ b/common/autoinstallers/command-plugins/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "rush-archive-project-plugin": "1.1.3",
+    "rush-archive-project-plugin": "link:../../../rush-plugins/rush-archive-project-plugin",
     "rush-audit-cache-plugin": "0.0.2",
     "rush-init-project-plugin": "0.6.0",
     "rush-lint-staged-plugin": "0.1.6",

--- a/common/autoinstallers/command-plugins/pnpm-lock.yaml
+++ b/common/autoinstallers/command-plugins/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.3
 
 specifiers:
-  rush-archive-project-plugin: 1.1.3
+  rush-archive-project-plugin: link:../../../rush-plugins/rush-archive-project-plugin
   rush-audit-cache-plugin: 0.0.2
   rush-init-project-plugin: 0.6.0
   rush-lint-staged-plugin: 0.1.6
@@ -10,7 +10,7 @@ specifiers:
   typescript: 4.4.2
 
 dependencies:
-  rush-archive-project-plugin: 1.1.3
+  rush-archive-project-plugin: link:../../../rush-plugins/rush-archive-project-plugin
   rush-audit-cache-plugin: 0.0.2
   rush-init-project-plugin: 0.6.0_typescript@4.4.2
   rush-lint-staged-plugin: 0.1.6
@@ -20,11 +20,11 @@ dependencies:
 
 packages:
 
-  /@babel/runtime-corejs3/7.20.6:
-    resolution: {integrity: sha512-tqeujPiuEfcH067mx+7otTQWROVMKHXEaOQcAeNV5dDdbPWvPcFA8/W9LXw2NfjNmOetqLl03dfnG2WALPlsRQ==}
+  /@babel/runtime-corejs3/7.20.7:
+    resolution: {integrity: sha512-jr9lCZ4RbRQmCR28Q8U8Fu49zvFqLxTY9AMOUz+iyMohMoAgpEcVxY+wJNay99oXOpOcCTODkk70NDN2aaJEeg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      core-js-pure: 3.26.1
+      core-js-pure: 3.27.1
       regenerator-runtime: 0.13.11
     dev: false
 
@@ -62,7 +62,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.14.0
+      fastq: 1.15.0
     dev: false
 
   /@npmcli/fs/1.1.1:
@@ -166,7 +166,7 @@ packages:
       resolve: 1.17.0
       semver: 7.3.8
       timsort: 0.3.0
-      z-schema: 5.0.4
+      z-schema: 5.0.5
     dev: false
 
   /@rushstack/rush-sdk/5.62.4:
@@ -207,7 +207,7 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: false
 
   /@types/inquirer/6.5.0:
@@ -224,21 +224,21 @@ packages:
   /@types/node-fetch/1.6.9:
     resolution: {integrity: sha512-n2r6WLoY7+uuPT7pnEtKJCmPUGyJ+cbyBR8Avnu4+m1nzz7DwBVuyIvvlBzCZ/nrpC7rIgb3D6pNavL7rFEa9g==}
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: false
 
   /@types/node/12.20.24:
     resolution: {integrity: sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==}
     dev: false
 
-  /@types/node/18.11.10:
-    resolution: {integrity: sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==}
+  /@types/node/18.11.18:
+    resolution: {integrity: sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==}
     dev: false
 
   /@types/through/0.0.30:
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
     dependencies:
-      '@types/node': 18.11.10
+      '@types/node': 18.11.18
     dev: false
 
   /abbrev/1.1.1:
@@ -707,7 +707,7 @@ packages:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
-      tar: 6.1.12
+      tar: 6.1.13
       unique-filename: 1.1.1
     dev: false
 
@@ -731,7 +731,7 @@ packages:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 9.0.1
-      tar: 6.1.12
+      tar: 6.1.13
       unique-filename: 2.0.1
     dev: false
 
@@ -845,14 +845,6 @@ packages:
     engines: {node: '>= 10'}
     dev: false
 
-  /cliui/7.0.4:
-    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-    dev: false
-
   /clone/1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
@@ -937,8 +929,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /core-js-pure/3.26.1:
-    resolution: {integrity: sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ==}
+  /core-js-pure/3.27.1:
+    resolution: {integrity: sha512-BS2NHgwwUppfeoqOXqi08mUqS5FiZpuRuJJpKsaME7kJz0xxuk0xkhDdfMIlP/zLa80krBqss1LtD7f889heAw==}
     requiresBuild: true
     dev: false
 
@@ -999,7 +991,7 @@ packages:
       ms: 2.1.2
     dev: false
 
-  /debug/4.3.4_supports-color@9.2.3:
+  /debug/4.3.4_supports-color@9.3.1:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
@@ -1009,7 +1001,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-      supports-color: 9.2.3
+      supports-color: 9.3.1
     dev: false
 
   /decode-uri-component/0.2.2:
@@ -1141,11 +1133,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /escalade/3.1.1:
-    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
-    engines: {node: '>=6'}
-    dev: false
-
   /escape-string-regexp/1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -1235,8 +1222,8 @@ packages:
       micromatch: 4.0.5
     dev: false
 
-  /fastq/1.14.0:
-    resolution: {integrity: sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==}
+  /fastq/1.15.0:
+    resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
     dependencies:
       reusify: 1.0.4
     dev: false
@@ -1335,11 +1322,6 @@ packages:
       wide-align: 1.1.5
     dev: false
 
-  /get-caller-file/2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
-    dev: false
-
   /get-object/0.2.0:
     resolution: {integrity: sha512-7P6y6k6EzEFmO/XyUyFlXm1YLJy9xeA1x/grNV8276abX5GuwUtYgKFkRFkLixw4hf4Pz9q2vgv/8Ar42R0HuQ==}
     engines: {node: '>=0.10.0'}
@@ -1387,7 +1369,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 5.1.1
+      minimatch: 5.1.2
       once: 1.4.0
     dev: false
 
@@ -1400,7 +1382,7 @@ packages:
       dir-glob: 3.0.1
       fast-glob: 3.2.12
       glob: 7.2.3
-      ignore: 5.2.1
+      ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
     dev: false
@@ -1414,7 +1396,7 @@ packages:
       dir-glob: 3.0.1
       fast-glob: 3.2.12
       glob: 7.2.3
-      ignore: 5.2.1
+      ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
     dev: false
@@ -1676,8 +1658,8 @@ packages:
     engines: {node: '>= 4'}
     dev: false
 
-  /ignore/5.2.1:
-    resolution: {integrity: sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==}
+  /ignore/5.2.4:
+    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
     dev: false
 
@@ -1763,7 +1745,7 @@ packages:
       mute-stream: 0.0.8
       ora: 5.4.1
       run-async: 2.4.1
-      rxjs: 7.6.0
+      rxjs: 7.8.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
       through: 2.3.8
@@ -2065,7 +2047,7 @@ packages:
       cli-truncate: 3.1.0
       colorette: 2.0.19
       commander: 8.3.0
-      debug: 4.3.4_supports-color@9.2.3
+      debug: 4.3.4_supports-color@9.3.1
       execa: 5.1.1
       lilconfig: 2.0.4
       listr2: 4.0.5
@@ -2073,7 +2055,7 @@ packages:
       normalize-path: 3.0.0
       object-inspect: 1.12.2
       string-argv: 0.3.1
-      supports-color: 9.2.3
+      supports-color: 9.3.1
       yaml: 1.10.2
     transitivePeerDependencies:
       - enquirer
@@ -2093,7 +2075,7 @@ packages:
       log-update: 4.0.0
       p-map: 4.0.0
       rfdc: 1.3.0
-      rxjs: 7.6.0
+      rxjs: 7.8.0
       through: 2.3.8
       wrap-ansi: 7.0.0
     dev: false
@@ -2314,8 +2296,8 @@ packages:
       brace-expansion: 1.1.11
     dev: false
 
-  /minimatch/5.1.1:
-    resolution: {integrity: sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==}
+  /minimatch/5.1.2:
+    resolution: {integrity: sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==}
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
@@ -2384,6 +2366,13 @@ packages:
 
   /minipass/3.3.6:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+    dependencies:
+      yallist: 4.0.0
+    dev: false
+
+  /minipass/4.0.0:
+    resolution: {integrity: sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==}
     engines: {node: '>=8'}
     dependencies:
       yallist: 4.0.0
@@ -2483,7 +2472,7 @@ packages:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.3.8
-      tar: 6.1.12
+      tar: 6.1.13
       which: 2.0.2
     transitivePeerDependencies:
       - supports-color
@@ -2493,7 +2482,7 @@ packages:
     resolution: {integrity: sha512-Cov028YhBZ5aB7MdMWJEmwyBig43aGL5WT4vdoB28Oitau1zZAcHUn8Sgfk9HM33TqhtLJ9PlM/O0Mv+QpV/4Q==}
     engines: {node: '>=8.9.4'}
     dependencies:
-      '@babel/runtime-corejs3': 7.20.6
+      '@babel/runtime-corejs3': 7.20.7
       '@types/inquirer': 6.5.0
       change-case: 3.1.0
       del: 5.1.0
@@ -2707,7 +2696,7 @@ packages:
       read-package-json-fast: 2.0.3
       rimraf: 3.0.2
       ssri: 8.0.1
-      tar: 6.1.12
+      tar: 6.1.13
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2857,11 +2846,6 @@ packages:
     engines: {node: '>=0.10'}
     dev: false
 
-  /require-directory/2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /resolve-url/0.2.1:
     resolution: {integrity: sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==}
     deprecated: https://github.com/lydell/resolve-url#deprecated
@@ -2925,18 +2909,6 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
-    dev: false
-
-  /rush-archive-project-plugin/1.1.3:
-    resolution: {integrity: sha512-duxYLiETHIs/uB5g7Fiu3GEsfypqeOoOdYF3091v9TRg9cVvAiw4RkhLk8tLgynDGsFcz4xD1XnkMMYJ8VPkiQ==}
-    hasBin: true
-    dependencies:
-      '@rushstack/node-core-library': 3.44.1
-      '@rushstack/rush-sdk': 5.62.4
-      inquirer: 8.2.5
-      ora: 5.4.1
-      tar: 6.1.12
-      yargs: 17.3.1
     dev: false
 
   /rush-audit-cache-plugin/0.0.2:
@@ -3014,8 +2986,8 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /rxjs/7.6.0:
-    resolution: {integrity: sha512-DDa7d8TFNUalGC9VqXvQ1euWNN7sc63TrUCuM9J998+ViviahMIjKSOU7rfcgFOF+FCD71BhDRv4hrFz+ImDLQ==}
+  /rxjs/7.8.0:
+    resolution: {integrity: sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==}
     dependencies:
       tslib: 2.4.1
     dev: false
@@ -3342,8 +3314,8 @@ packages:
       has-flag: 4.0.0
     dev: false
 
-  /supports-color/9.2.3:
-    resolution: {integrity: sha512-aszYUX/DVK/ed5rFLb/dDinVJrQjG/vmU433wtqVSD800rYsJNWxh2R3USV90aLSU+UsyQkbNeffVLzc6B6foA==}
+  /supports-color/9.3.1:
+    resolution: {integrity: sha512-knBY82pjmnIzK3NifMo3RxEIRD9E0kIzV4BKcyTZ9+9kWgLMxd4PrsTSMoFQUabgRBbF8KOLRDCyKgNV+iK44Q==}
     engines: {node: '>=12'}
     dev: false
 
@@ -3364,13 +3336,13 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /tar/6.1.12:
-    resolution: {integrity: sha512-jU4TdemS31uABHd+Lt5WEYJuzn+TJTCBLljvIAHZOz6M9Os5pJ4dD+vRFLxPa/n3T0iEFzpi+0x1UfuDZYbRMw==}
+  /tar/6.1.13:
+    resolution: {integrity: sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==}
     engines: {node: '>=10'}
     dependencies:
       chownr: 2.0.0
       fs-minipass: 2.1.0
-      minipass: 3.3.6
+      minipass: 4.0.0
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
@@ -3655,11 +3627,6 @@ packages:
     engines: {node: '>=0.4'}
     dev: false
 
-  /y18n/5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-    dev: false
-
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: false
@@ -3667,24 +3634,6 @@ packages:
   /yaml/1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
-    dev: false
-
-  /yargs-parser/21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /yargs/17.3.1:
-    resolution: {integrity: sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==}
-    engines: {node: '>=12'}
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.1.1
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
     dev: false
 
   /year/0.2.1:
@@ -3713,8 +3662,8 @@ packages:
       commander: 2.20.3
     dev: false
 
-  /z-schema/5.0.4:
-    resolution: {integrity: sha512-gm/lx3hDzJNcLwseIeQVm1UcwhWIKpSB4NqH89pTBtFns4k/HDHudsICtvG05Bvw/Mv3jMyk700y5dadueLHdA==}
+  /z-schema/5.0.5:
+    resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
     engines: {node: '>=8.0.0'}
     hasBin: true
     dependencies:
@@ -3722,5 +3671,5 @@ packages:
       lodash.isequal: 4.5.0
       validator: 13.7.0
     optionalDependencies:
-      commander: 2.20.3
+      commander: 9.4.1
     dev: false

--- a/common/autoinstallers/command-plugins/pnpm-lock.yaml
+++ b/common/autoinstallers/command-plugins/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.3
 
 specifiers:
-  rush-archive-project-plugin: link:../../../rush-plugins/rush-archive-project-plugin
+  rush-archive-project-plugin: 1.1.3
   rush-audit-cache-plugin: 0.0.2
   rush-init-project-plugin: 0.6.0
   rush-lint-staged-plugin: 0.1.6
@@ -10,7 +10,7 @@ specifiers:
   typescript: 4.4.2
 
 dependencies:
-  rush-archive-project-plugin: link:../../../rush-plugins/rush-archive-project-plugin
+  rush-archive-project-plugin: 1.1.3
   rush-audit-cache-plugin: 0.0.2
   rush-init-project-plugin: 0.6.0_typescript@4.4.2
   rush-lint-staged-plugin: 0.1.6
@@ -845,6 +845,14 @@ packages:
     engines: {node: '>= 10'}
     dev: false
 
+  /cliui/7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: false
+
   /clone/1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
@@ -1133,6 +1141,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /escalade/3.1.1:
+    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
+    engines: {node: '>=6'}
+    dev: false
+
   /escape-string-regexp/1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -1320,6 +1333,11 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wide-align: 1.1.5
+    dev: false
+
+  /get-caller-file/2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
     dev: false
 
   /get-object/0.2.0:
@@ -2846,6 +2864,11 @@ packages:
     engines: {node: '>=0.10'}
     dev: false
 
+  /require-directory/2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /resolve-url/0.2.1:
     resolution: {integrity: sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==}
     deprecated: https://github.com/lydell/resolve-url#deprecated
@@ -2909,6 +2932,18 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
+    dev: false
+
+  /rush-archive-project-plugin/1.1.3:
+    resolution: {integrity: sha512-duxYLiETHIs/uB5g7Fiu3GEsfypqeOoOdYF3091v9TRg9cVvAiw4RkhLk8tLgynDGsFcz4xD1XnkMMYJ8VPkiQ==}
+    hasBin: true
+    dependencies:
+      '@rushstack/node-core-library': 3.44.1
+      '@rushstack/rush-sdk': 5.62.4
+      inquirer: 8.2.5
+      ora: 5.4.1
+      tar: 6.1.13
+      yargs: 17.3.1
     dev: false
 
   /rush-audit-cache-plugin/0.0.2:
@@ -3627,6 +3662,11 @@ packages:
     engines: {node: '>=0.4'}
     dev: false
 
+  /y18n/5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+    dev: false
+
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: false
@@ -3634,6 +3674,24 @@ packages:
   /yaml/1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
+    dev: false
+
+  /yargs-parser/21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /yargs/17.3.1:
+    resolution: {integrity: sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
     dev: false
 
   /year/0.2.1:

--- a/common/changes/rush-archive-project-plugin/will-archive-git-history_2023-01-03-22-07.json
+++ b/common/changes/rush-archive-project-plugin/will-archive-git-history_2023-01-03-22-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-archive-project-plugin",
+      "comment": "Updated to include a git checkpoint branch when archiving a project",
+      "type": "patch"
+    }
+  ],
+  "packageName": "rush-archive-project-plugin"
+}

--- a/rush-plugins/rush-archive-project-plugin/src/cli.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/cli.ts
@@ -25,7 +25,12 @@ async function main(): Promise<void> {
             type: "string",
             describe: "The name of the package to archive",
           })
-          .demandOption(["packageName"]);
+          .option("gitCheckpoint", {
+            type: "boolean",
+            describe: "Create a git checkpoint before archival"
+          })
+          .default('gitCheckpoint', true)
+          .demandOption(["packageName", "gitCheckpoint"]);
       },
       async (argv) => {
         const { archive } = await import("./commands/archive");

--- a/rush-plugins/rush-archive-project-plugin/src/commands/archive.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/commands/archive.ts
@@ -41,7 +41,7 @@ ${consumingProjectNames.join(", ")}`);
     spinner = ora('attempting to create a git checkpoint');
     const branchName: string = getCheckpointBranch(rushConfiguration.rushJsonFolder,packageName);
     spinner.succeed(`Git Checkpoint created at branch: ${branchName}`);
-    return;
+    process.exit(0);
   }
 
   const { projectFolder, projectRelativeFolder } = project;

--- a/rush-plugins/rush-archive-project-plugin/src/commands/archive.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/commands/archive.ts
@@ -38,9 +38,10 @@ ${consumingProjectNames.join(", ")}`);
   }
 
   if (gitCheckpoint) {
-      spinner = ora('attempting to create a git checkpoint');
-      const branchName: string = getCheckpointBranch(packageName);
-      spinner.succeed(`Git Checkpoint created at branch: ${branchName}`);
+    spinner = ora('attempting to create a git checkpoint');
+    const branchName: string = getCheckpointBranch(rushConfiguration.rushJsonFolder,packageName);
+    spinner.succeed(`Git Checkpoint created at branch: ${branchName}`);
+    return;
   }
 
   const { projectFolder, projectRelativeFolder } = project;

--- a/rush-plugins/rush-archive-project-plugin/src/commands/archive.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/commands/archive.ts
@@ -5,7 +5,7 @@ import type {
 import { FileSystem, JsonFile, JsonObject } from "@rushstack/node-core-library";
 import * as path from "path";
 import * as tar from "tar";
-import { gitCheckIgnored, gitFullClean } from "../logic/git";
+import { getCheckpointBranch, gitCheckIgnored, gitFullClean } from "../logic/git";
 import { getGraveyardInfo } from "../logic/graveyard";
 import { ProjectMetadata } from "../logic/projectMetadata";
 import ora from "ora";
@@ -13,9 +13,10 @@ import { loadRushConfiguration } from "../logic/rushConfiguration";
 
 interface IArchiveConfig {
   packageName: string;
+  gitCheckpoint: boolean;
 }
 
-export async function archive({ packageName }: IArchiveConfig): Promise<void> {
+export async function archive({ packageName, gitCheckpoint }: IArchiveConfig): Promise<void> {
   let spinner: ora.Ora | undefined;
   const rushConfiguration: RushConfiguration = loadRushConfiguration();
   const monoRoot: string = rushConfiguration.rushJsonFolder;
@@ -34,6 +35,12 @@ export async function archive({ packageName }: IArchiveConfig): Promise<void> {
       consumingProjectNames.length
     } project(s):
 ${consumingProjectNames.join(", ")}`);
+  }
+
+  if (gitCheckpoint) {
+      spinner = ora('attempting to create a git checkpoint');
+      const branchName: string = getCheckpointBranch(packageName);
+      spinner.succeed(`Git Checkpoint created at branch: ${branchName}`);
   }
 
   const { projectFolder, projectRelativeFolder } = project;

--- a/rush-plugins/rush-archive-project-plugin/src/commands/archive.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/commands/archive.ts
@@ -74,7 +74,6 @@ ${consumingProjectNames.join(", ")}`);
       description
     }
     JsonFile.save(archivedProjectMetadataObject, archivedProjectMetadataFilePath);
-    process.exit(0);
   }
 
   // create a metadata.json file

--- a/rush-plugins/rush-archive-project-plugin/src/commands/test/archive.test.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/commands/test/archive.test.ts
@@ -45,6 +45,7 @@ describe("archive", () => {
       await expect(
         archive({
           packageName,
+          gitCheckpoint: false
         })
       ).rejects.toThrow(
         `Could not find project with package name ${packageName}`
@@ -57,6 +58,7 @@ describe("archive", () => {
         await expect(
           archive({
             packageName,
+            gitCheckpoint: false
           })
         ).resolves.toBeUndefined();
       });
@@ -87,6 +89,7 @@ describe("archive", () => {
       await expect(
         archive({
           packageName,
+          gitCheckpoint: false
         })
       ).resolves.toBeUndefined();
     });
@@ -116,6 +119,7 @@ describe("archive", () => {
       await expect(
         archive({
           packageName,
+          gitCheckpoint: false
         })
       ).rejects.toThrowErrorMatchingSnapshot();
     });

--- a/rush-plugins/rush-archive-project-plugin/src/logic/git.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/logic/git.ts
@@ -55,9 +55,14 @@ export const gitCheckIgnored = (cwd: string, filePath: string): string => {
 
 export const getCheckpointBranch = (cwd: string, branchName: string): string => {
   const gitPath: string = getGitPathOrThrow();
-  const archivedBranchName: string = `${branchName}-checkpoint-${new Date().toISOString()}`;
-  Executable.spawnSync(gitPath, ["branch", archivedBranchName], {
+  const currDate: string = new Date().toISOString().substring(0, 10);
+  const branchNameToCreate: string = `${branchName}-checkpoint-${currDate}`;
+  const process: SpawnSyncReturns<string> = Executable.spawnSync(gitPath, ["branch", branchNameToCreate], {
     currentWorkingDirectory: cwd,
   });
-  return archivedBranchName;
+  if (process.status === 128) {
+    throw new Error(`The passed branch name is invalid: ${branchNameToCreate}`)
+  }
+
+  return branchNameToCreate;
 }

--- a/rush-plugins/rush-archive-project-plugin/src/logic/git.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/logic/git.ts
@@ -53,9 +53,11 @@ export const gitCheckIgnored = (cwd: string, filePath: string): string => {
   return result;
 };
 
-export const getCheckpointBranch = (branchName: string): string => {
+export const getCheckpointBranch = (cwd: string, branchName: string): string => {
   const gitPath: string = getGitPathOrThrow();
   const archivedBranchName: string = `${branchName}-checkpoint-${new Date().toISOString()}`;
-  Executable.spawnSync(gitPath, ["branch", archivedBranchName]);
+  Executable.spawnSync(gitPath, ["branch", archivedBranchName], {
+    currentWorkingDirectory: cwd,
+  });
   return archivedBranchName;
 }

--- a/rush-plugins/rush-archive-project-plugin/src/logic/git.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/logic/git.ts
@@ -52,3 +52,10 @@ export const gitCheckIgnored = (cwd: string, filePath: string): string => {
   }
   return result;
 };
+
+export const getCheckpointBranch = (branchName: string): string => {
+  const gitPath: string = getGitPathOrThrow();
+  const archivedBranchName: string = `${branchName}-checkpoint-${new Date().toISOString()}`;
+  Executable.spawnSync(gitPath, ["branch", archivedBranchName]);
+  return archivedBranchName;
+}

--- a/rush-plugins/rush-archive-project-plugin/src/logic/projectMetadata.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/logic/projectMetadata.ts
@@ -28,3 +28,9 @@ export class ProjectMetadata {
     return this._projectConfig;
   }
 }
+
+export interface IProjectCheckpointMetadata {
+  checkpointBranch: string;
+  archivedOn: string;
+  description: string;
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [x] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary
This PR adds the ability to create a git branch as a "checkpoint" when archiving a project. The purpose of this is to maintain a "snapshot" of the current monorepo state as well as a .zip file of the project contents. This way, a user can easily re-visit the state of the monorepo while the package was still part of the monorepo, without worrying about any breaking changes that may have been introduced since the package was archived.

### Detail
This feature is done by the following steps:
- Create a git branch with the name in the format of `${packageName}-checkpoint-${currentDate}`
- Create / Update the metadata file with the created branch name, and save it in the same _graveyard folder as the archived project

### How to test it
