### PR TITLE
[rush-archive-project-plugin]: Add md file for archived projects

### DIFF
--- a/common/autoinstallers/command-plugins/package.json
+++ b/common/autoinstallers/command-plugins/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "rush-archive-project-plugin": "link:../../../rush-plugins/rush-archive-project-plugin",
+    "rush-archive-project-plugin": "1.1.3",
     "rush-audit-cache-plugin": "0.0.2",
     "rush-init-project-plugin": "0.6.0",
     "rush-lint-staged-plugin": "0.1.6",

--- a/common/autoinstallers/command-plugins/package.json
+++ b/common/autoinstallers/command-plugins/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "rush-archive-project-plugin": "1.1.3",
+    "rush-archive-project-plugin": "link:../../../rush-plugins/rush-archive-project-plugin",
     "rush-audit-cache-plugin": "0.0.2",
     "rush-init-project-plugin": "0.6.0",
     "rush-lint-staged-plugin": "0.1.6",

--- a/common/autoinstallers/command-plugins/pnpm-lock.yaml
+++ b/common/autoinstallers/command-plugins/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.3
 
 specifiers:
-  rush-archive-project-plugin: link:../../../rush-plugins/rush-archive-project-plugin
+  rush-archive-project-plugin: 1.1.3
   rush-audit-cache-plugin: 0.0.2
   rush-init-project-plugin: 0.6.0
   rush-lint-staged-plugin: 0.1.6
@@ -10,7 +10,7 @@ specifiers:
   typescript: 4.4.2
 
 dependencies:
-  rush-archive-project-plugin: link:../../../rush-plugins/rush-archive-project-plugin
+  rush-archive-project-plugin: 1.1.3
   rush-audit-cache-plugin: 0.0.2
   rush-init-project-plugin: 0.6.0_typescript@4.4.2
   rush-lint-staged-plugin: 0.1.6
@@ -845,6 +845,14 @@ packages:
     engines: {node: '>= 10'}
     dev: false
 
+  /cliui/7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: false
+
   /clone/1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
@@ -1140,6 +1148,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /escalade/3.1.1:
+    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
+    engines: {node: '>=6'}
+    dev: false
+
   /escape-string-regexp/1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -1327,6 +1340,11 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wide-align: 1.1.5
+    dev: false
+
+  /get-caller-file/2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
     dev: false
 
   /get-object/0.2.0:
@@ -2060,7 +2078,7 @@ packages:
       listr2: 4.0.5
       micromatch: 4.0.5
       normalize-path: 3.0.0
-      object-inspect: 1.12.2
+      object-inspect: 1.12.3
       string-argv: 0.3.1
       supports-color: 9.3.1
       yaml: 1.10.2
@@ -2601,8 +2619,8 @@ packages:
       kind-of: 3.2.2
     dev: false
 
-  /object-inspect/1.12.2:
-    resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
+  /object-inspect/1.12.3:
+    resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
     dev: false
 
   /object-visit/1.0.1:
@@ -2853,6 +2871,11 @@ packages:
     engines: {node: '>=0.10'}
     dev: false
 
+  /require-directory/2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /resolve-url/0.2.1:
     resolution: {integrity: sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==}
     deprecated: https://github.com/lydell/resolve-url#deprecated
@@ -2916,6 +2939,18 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
+    dev: false
+
+  /rush-archive-project-plugin/1.1.3:
+    resolution: {integrity: sha512-duxYLiETHIs/uB5g7Fiu3GEsfypqeOoOdYF3091v9TRg9cVvAiw4RkhLk8tLgynDGsFcz4xD1XnkMMYJ8VPkiQ==}
+    hasBin: true
+    dependencies:
+      '@rushstack/node-core-library': 3.44.1
+      '@rushstack/rush-sdk': 5.62.4
+      inquirer: 8.2.5
+      ora: 5.4.1
+      tar: 6.1.13
+      yargs: 17.3.1
     dev: false
 
   /rush-audit-cache-plugin/0.0.2:
@@ -3634,6 +3669,11 @@ packages:
     engines: {node: '>=0.4'}
     dev: false
 
+  /y18n/5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+    dev: false
+
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: false
@@ -3641,6 +3681,24 @@ packages:
   /yaml/1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
+    dev: false
+
+  /yargs-parser/21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /yargs/17.3.1:
+    resolution: {integrity: sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
     dev: false
 
   /year/0.2.1:

--- a/common/autoinstallers/command-plugins/pnpm-lock.yaml
+++ b/common/autoinstallers/command-plugins/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.3
 
 specifiers:
-  rush-archive-project-plugin: 1.1.3
+  rush-archive-project-plugin: link:../../../rush-plugins/rush-archive-project-plugin
   rush-audit-cache-plugin: 0.0.2
   rush-init-project-plugin: 0.6.0
   rush-lint-staged-plugin: 0.1.6
@@ -10,7 +10,7 @@ specifiers:
   typescript: 4.4.2
 
 dependencies:
-  rush-archive-project-plugin: 1.1.3
+  rush-archive-project-plugin: link:../../../rush-plugins/rush-archive-project-plugin
   rush-audit-cache-plugin: 0.0.2
   rush-init-project-plugin: 0.6.0_typescript@4.4.2
   rush-lint-staged-plugin: 0.1.6
@@ -845,14 +845,6 @@ packages:
     engines: {node: '>= 10'}
     dev: false
 
-  /cliui/7.0.4:
-    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-    dev: false
-
   /clone/1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
@@ -906,6 +898,13 @@ packages:
     resolution: {integrity: sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==}
     engines: {node: ^12.20.0 || >=14}
     dev: false
+
+  /commander/9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /component-emitter/1.3.0:
     resolution: {integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==}
@@ -1141,11 +1140,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /escalade/3.1.1:
-    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
-    engines: {node: '>=6'}
-    dev: false
-
   /escape-string-regexp/1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -1333,11 +1327,6 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wide-align: 1.1.5
-    dev: false
-
-  /get-caller-file/2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
     dev: false
 
   /get-object/0.2.0:
@@ -2864,11 +2853,6 @@ packages:
     engines: {node: '>=0.10'}
     dev: false
 
-  /require-directory/2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /resolve-url/0.2.1:
     resolution: {integrity: sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==}
     deprecated: https://github.com/lydell/resolve-url#deprecated
@@ -2932,18 +2916,6 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
-    dev: false
-
-  /rush-archive-project-plugin/1.1.3:
-    resolution: {integrity: sha512-duxYLiETHIs/uB5g7Fiu3GEsfypqeOoOdYF3091v9TRg9cVvAiw4RkhLk8tLgynDGsFcz4xD1XnkMMYJ8VPkiQ==}
-    hasBin: true
-    dependencies:
-      '@rushstack/node-core-library': 3.44.1
-      '@rushstack/rush-sdk': 5.62.4
-      inquirer: 8.2.5
-      ora: 5.4.1
-      tar: 6.1.13
-      yargs: 17.3.1
     dev: false
 
   /rush-audit-cache-plugin/0.0.2:
@@ -3662,11 +3634,6 @@ packages:
     engines: {node: '>=0.4'}
     dev: false
 
-  /y18n/5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-    dev: false
-
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: false
@@ -3674,24 +3641,6 @@ packages:
   /yaml/1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
-    dev: false
-
-  /yargs-parser/21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /yargs/17.3.1:
-    resolution: {integrity: sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==}
-    engines: {node: '>=12'}
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.1.1
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
     dev: false
 
   /year/0.2.1:
@@ -3729,5 +3678,5 @@ packages:
       lodash.isequal: 4.5.0
       validator: 13.7.0
     optionalDependencies:
-      commander: 9.4.1
+      commander: 9.5.0
     dev: false

--- a/common/changes/rush-archive-project-plugin/will-archive-project-md_2023-01-12-22-00.json
+++ b/common/changes/rush-archive-project-plugin/will-archive-project-md_2023-01-12-22-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-archive-project-plugin",
+      "comment": "Add ability to push git branch and generate md file for archived projects\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "rush-archive-project-plugin"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -15,6 +15,7 @@ importers:
       '@rushstack/rush-sdk': 5.62.4
       '@types/heft-jest': 1.0.1
       '@types/inquirer': ~8.1.3
+      '@types/json2md': ~1.5.1
       '@types/node': 12.20.24
       '@types/pacote': ~11.1.1
       '@types/tar': ~6.1.1
@@ -41,6 +42,7 @@ importers:
       '@rushstack/heft-node-rig': 1.2.31_@rushstack+heft@0.43.2
       '@types/heft-jest': 1.0.1
       '@types/inquirer': 8.1.3
+      '@types/json2md': 1.5.1
       '@types/node': 12.20.24
       '@types/pacote': 11.1.1
       '@types/tar': 6.1.1
@@ -1425,6 +1427,10 @@ packages:
 
   /@types/json-schema/7.0.9:
     resolution: {integrity: sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==}
+    dev: true
+
+  /@types/json2md/1.5.1:
+    resolution: {integrity: sha512-nl3qRDdBUtGeHEhwSeYMtXw5i6UXspS6pxaahmcrE4Fxt0UAvKvsJzu6UMtJ85+yTYiB9nA0TB1kFMEVkYDgUg==}
     dev: true
 
   /@types/lodash/4.14.184:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -21,6 +21,7 @@ importers:
       '@types/yargs': ~17.0.7
       eslint: 7.32.0
       inquirer: ~8.2.0
+      json2md: ~2.0.0
       ora: 5.4.1
       tar: ~6.1.11
       typescript: 4.4.2
@@ -29,6 +30,7 @@ importers:
       '@rushstack/node-core-library': 3.44.1
       '@rushstack/rush-sdk': 5.62.4
       inquirer: 8.2.0
+      json2md: 2.0.0
       ora: 5.4.1
       tar: 6.1.11
       yargs: 17.3.0
@@ -4106,6 +4108,10 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  /indento/1.1.13:
+    resolution: {integrity: sha512-YZWk3mreBEM7sBPddsiQnW9Z8SGg/gNpFfscJq00HCDS7pxcQWWWMSVKJU7YkTRyDu1Zv2s8zaK8gQWKmCXHlg==}
+    dev: false
+
   /infer-owner/1.0.4:
     resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
     dev: false
@@ -5102,6 +5108,12 @@ packages:
   /json-stringify-safe/5.0.1:
     resolution: {integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=}
     dev: true
+
+  /json2md/2.0.0:
+    resolution: {integrity: sha512-4PIMtD0zTfQZWcUId1EyHY2BQ2EG/imHWHkGFbXYPlczW8G6wPJA/BRVN3e5v6NPwFUCcoFvUsCeo6rzV2CWww==}
+    dependencies:
+      indento: 1.1.13
+    dev: false
 
   /json5/2.2.0:
     resolution: {integrity: sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==}

--- a/rush-plugins/rush-archive-project-plugin/package.json
+++ b/rush-plugins/rush-archive-project-plugin/package.json
@@ -33,10 +33,10 @@
     "@rushstack/node-core-library": "3.44.1",
     "@rushstack/rush-sdk": "5.62.4",
     "inquirer": "~8.2.0",
+    "json2md": "~2.0.0",
     "ora": "5.4.1",
     "tar": "~6.1.11",
-    "yargs": "~17.3.0",
-    "json2md": "~2.0.0"
+    "yargs": "~17.3.0"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "2.4.5",
@@ -45,12 +45,12 @@
     "@rushstack/heft-node-rig": "1.2.31",
     "@types/heft-jest": "1.0.1",
     "@types/inquirer": "~8.1.3",
+    "@types/json2md": "~1.5.1",
     "@types/node": "12.20.24",
     "@types/pacote": "~11.1.1",
     "@types/tar": "~6.1.1",
     "@types/yargs": "~17.0.7",
     "eslint": "7.32.0",
-    "typescript": "4.4.2",
-    "@types/json2md": "~1.5.1"
+    "typescript": "4.4.2"
   }
 }

--- a/rush-plugins/rush-archive-project-plugin/package.json
+++ b/rush-plugins/rush-archive-project-plugin/package.json
@@ -50,6 +50,7 @@
     "@types/tar": "~6.1.1",
     "@types/yargs": "~17.0.7",
     "eslint": "7.32.0",
-    "typescript": "4.4.2"
+    "typescript": "4.4.2",
+    "@types/json2md": "~1.5.1"
   }
 }

--- a/rush-plugins/rush-archive-project-plugin/package.json
+++ b/rush-plugins/rush-archive-project-plugin/package.json
@@ -35,7 +35,8 @@
     "inquirer": "~8.2.0",
     "ora": "5.4.1",
     "tar": "~6.1.11",
-    "yargs": "~17.3.0"
+    "yargs": "~17.3.0",
+    "json2md": "~2.0.0"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "2.4.5",

--- a/rush-plugins/rush-archive-project-plugin/src/commands/archive.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/commands/archive.ts
@@ -5,8 +5,8 @@ import type {
 import { FileSystem, JsonFile, JsonObject } from "@rushstack/node-core-library";
 import * as path from "path";
 import * as tar from "tar";
-import { getCheckpointBranch, gitCheckIgnored, gitFullClean } from "../logic/git";
-import { getGraveyardInfo } from "../logic/graveyard";
+import { getCheckpointBranch, gitCheckIgnored, gitFullClean, pushGitBranch } from "../logic/git";
+import { getGraveyardInfo, graveyardRelativeFolder } from "../logic/graveyard";
 import { IProjectCheckpointMetadata, ProjectMetadata } from "../logic/projectMetadata";
 import ora from "ora";
 import inquirer from 'inquirer';
@@ -61,11 +61,10 @@ ${consumingProjectNames.join(", ")}`);
       { type: 'confirm', name: 'pushBranch', message: 'Push checkpoint branch to remote?' }
     ])
     if (pushBranch) {
-      console.log('pushing branch...');
+      pushGitBranch(rushConfiguration.rushJsonFolder, branchName);
     }
-    process.exit(1);
     // Add data to metadata file
-    const archivedProjectMetadataFilePath: string = `${tarballFolder}/projectCheckpoints.json`;
+    const archivedProjectMetadataFilePath: string = path.join(monoRoot, graveyardRelativeFolder, 'projectCheckpoints.json');
     let archivedProjectMetadataObject: { [key in string]: IProjectCheckpointMetadata } = {};
     if (FileSystem.exists(archivedProjectMetadataFilePath)) {
       archivedProjectMetadataObject = JsonFile.load(archivedProjectMetadataFilePath);

--- a/rush-plugins/rush-archive-project-plugin/src/commands/archive.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/commands/archive.ts
@@ -9,6 +9,7 @@ import { getCheckpointBranch, gitCheckIgnored, gitFullClean } from "../logic/git
 import { getGraveyardInfo } from "../logic/graveyard";
 import { IProjectCheckpointMetadata, ProjectMetadata } from "../logic/projectMetadata";
 import ora from "ora";
+import inquirer from 'inquirer';
 import { loadRushConfiguration } from "../logic/rushConfiguration";
 
 interface IArchiveConfig {
@@ -55,6 +56,14 @@ ${consumingProjectNames.join(", ")}`);
     spinner = ora('Attempting to create a git checkpoint branch');
     const branchName: string = getCheckpointBranch(rushConfiguration.rushJsonFolder,packageName);
     spinner.succeed(`Git Checkpoint created at branch: ${branchName}`);
+    // Prompt user to push the newly created branch
+    const { pushBranch } = await inquirer.prompt([
+      { type: 'confirm', name: 'pushBranch', message: 'Push checkpoint branch to remote?' }
+    ])
+    if (pushBranch) {
+      console.log('pushing branch...');
+    }
+    process.exit(1);
     // Add data to metadata file
     const archivedProjectMetadataFilePath: string = `${tarballFolder}/projectCheckpoints.json`;
     let archivedProjectMetadataObject: { [key in string]: IProjectCheckpointMetadata } = {};

--- a/rush-plugins/rush-archive-project-plugin/src/commands/archive.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/commands/archive.ts
@@ -11,8 +11,8 @@ import { IProjectCheckpointMetadata, ProjectMetadata } from "../logic/projectMet
 import ora from "ora";
 import inquirer from 'inquirer';
 import fs from 'fs';
-import json2md from 'json2md';
 import { loadRushConfiguration } from "../logic/rushConfiguration";
+import { convertProjectMetadataToMD } from "../logic/generateMD";
 
 interface IArchiveConfig {
   packageName: string;
@@ -85,26 +85,8 @@ ${consumingProjectNames.join(", ")}`);
       description
     }
     JsonFile.save(archivedProjectMetadataObject, archivedProjectMetadataFilePath);
-    // Try saving a md file of this json file
-    const mdFileContents: any = [
-      { h2: "Archived Projects" }
-    ];
-    const tableRows: any = []
-    for (const [projectName, projectMetadata] of Object.entries(archivedProjectMetadataObject)) {
-      tableRows.push([
-        projectName,
-        projectMetadata.checkpointBranch,
-        projectMetadata.description,
-        projectMetadata.archivedOn
-      ])
-    }
-    mdFileContents.push({
-      table: {
-        headers: ["Project Name", "Checkpoint Branch", "Description", "Archive Date"],
-        rows: tableRows
-      }
-    })
-    fs.writeFileSync(archivedProjectMetadataMdFilePath, json2md(mdFileContents));
+
+    fs.writeFileSync(archivedProjectMetadataMdFilePath, convertProjectMetadataToMD(archivedProjectMetadataObject));
   }
 
   // create a metadata.json file

--- a/rush-plugins/rush-archive-project-plugin/src/commands/archive.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/commands/archive.ts
@@ -89,18 +89,21 @@ ${consumingProjectNames.join(", ")}`);
     const mdFileContents: any = [
       { h2: "Archived Projects" }
     ];
+    const tableRows: any = []
     for (const [projectName, projectMetadata] of Object.entries(archivedProjectMetadataObject)) {
-      const projectMdDetails: any = [
-        { h3: projectName },
-        { h5: "Checkpoint Branch" },
-        { p: projectMetadata.checkpointBranch },
-        { h5: "Project Description" },
-        { p: projectMetadata.description },
-        { h5: "Archived on Date:" },
-        { p: projectMetadata.archivedOn },
-      ]
-      mdFileContents.push(...projectMdDetails);
+      tableRows.push([
+        projectName,
+        projectMetadata.checkpointBranch,
+        projectMetadata.description,
+        projectMetadata.archivedOn
+      ])
     }
+    mdFileContents.push({
+      table: {
+        headers: ["Project Name", "Checkpoint Branch", "Description", "Archive Date"],
+        rows: tableRows
+      }
+    })
     fs.writeFileSync(archivedProjectMetadataMdFilePath, json2md(mdFileContents));
   }
 

--- a/rush-plugins/rush-archive-project-plugin/src/logic/generateMD.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/logic/generateMD.ts
@@ -1,4 +1,26 @@
-// Generate a md file with the corresponding json content for archived projects
-export const generateMD = (jsonContent: any): void => {
+import json2md from 'json2md';
+import { IProjectCheckpointMetadata } from './projectMetadata';
 
+// Generate a md file with the corresponding json content for archived projects
+export const convertProjectMetadataToMD = (archivedProjectMetadataObject: { [key in string]: IProjectCheckpointMetadata }): string => {
+// Try saving a md file of this json file
+    const mdFileContents: any = [
+      { h2: "Archived Projects" }
+    ];
+    const tableRows: any = []
+    for (const [projectName, projectMetadata] of Object.entries(archivedProjectMetadataObject)) {
+      tableRows.push([
+        projectName,
+        projectMetadata.checkpointBranch,
+        projectMetadata.description,
+        projectMetadata.archivedOn
+      ])
+    }
+    mdFileContents.push({
+      table: {
+        headers: ["Project Name", "Checkpoint Branch", "Description", "Archive Date"],
+        rows: tableRows
+      }
+    })
+    return json2md(mdFileContents);
 }

--- a/rush-plugins/rush-archive-project-plugin/src/logic/generateMD.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/logic/generateMD.ts
@@ -1,0 +1,4 @@
+// Generate a md file with the corresponding json content for archived projects
+export const generateMD = (jsonContent: any): void => {
+
+}

--- a/rush-plugins/rush-archive-project-plugin/src/logic/git.ts
+++ b/rush-plugins/rush-archive-project-plugin/src/logic/git.ts
@@ -66,3 +66,13 @@ export const getCheckpointBranch = (cwd: string, branchName: string): string => 
 
   return branchNameToCreate;
 }
+
+export const pushGitBranch = (cwd: string, branchName: string): void => {
+  const gitPath: string = getGitPathOrThrow();
+  const process: SpawnSyncReturns<string> = Executable.spawnSync(gitPath, ["push", "origin", `${branchName}:${branchName}`], {
+    currentWorkingDirectory: cwd,
+  });
+  if (process.status !== 0) {
+    console.error('Could not push branch to origin');
+  }
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary
This PR adds the following changes:
- Query user if they would like to push the checkpoint to remote
- Save the archived project details json to the root graveyard folder
- Generate a MD file for better user readability next to the archived project details json file
### Detail

### How to test it
