### PR TITLE
feat: add answers config to template init

### DIFF
--- a/common/changes/rush-init-project-plugin/feat-rush-init-project-default-answer_2023-02-16-07-07.json
+++ b/common/changes/rush-init-project-plugin/feat-rush-init-project-default-answer_2023-02-16-07-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-init-project-plugin",
+      "comment": "add answers config to template config",
+      "type": "minor"
+    }
+  ],
+  "packageName": "rush-init-project-plugin"
+}

--- a/rush-plugins/rush-init-project-plugin/docs/init_project_configuration.md
+++ b/rush-plugins/rush-init-project-plugin/docs/init_project_configuration.md
@@ -20,6 +20,7 @@ const config = {
   prompts: [],
   plugins: [],
   defaultProjectConfiguration: {},
+  answers: {} // cli answers are prior to answers config in template
 };
 module.exports = config;
 ```
@@ -473,7 +474,7 @@ export class MyDataPlugin implements IPlugin {
   public static readonly pluginName: string = 'MyDataPlugin';
   apply(hooks: IHooks): void {
     hooks.answers.tap(MyDataPlugin.pluginName, (answers) => {
-      // mutate answers here 
+      // mutate answers here
       answers.foo = 'foo';
       answers.bar = 'bar';
     });

--- a/rush-plugins/rush-init-project-plugin/src/logic/TemplateConfiguration.ts
+++ b/rush-plugins/rush-init-project-plugin/src/logic/TemplateConfiguration.ts
@@ -1,29 +1,30 @@
-import type { PromptQuestion } from "node-plop";
-import { getTemplateFolder } from "./templateFolder";
-import { lilconfigSync, LilconfigResult } from "lilconfig";
-import type { IHooks } from "../hooks";
+import type { PromptQuestion } from 'node-plop';
+import { getTemplateFolder } from './templateFolder';
+import { lilconfigSync, LilconfigResult } from 'lilconfig';
+import type { IHooks } from '../hooks';
+import { Answers } from 'inquirer';
 
-const searchPlaces: string[] = ["init.config.ts", "init.config.js"];
+const searchPlaces: string[] = ['init.config.ts', 'init.config.js'];
 
 const loaders: Record<string, (path: string) => IConfig> = {
-  ".js": (path) => require(path),
-  ".ts": (path) => {
-    require("ts-node").register({
+  '.js': (path) => require(path),
+  '.ts': (path) => {
+    require('ts-node').register({
       transpileOnly: true,
       compilerOptions: {
-        esModuleInterop: true,
-      },
+        esModuleInterop: true
+      }
     });
     const module: any = require(path);
     try {
-      if ("default" in module) {
+      if ('default' in module) {
         return module.default;
       }
     } catch {
       // no-catch
     }
     return module;
-  },
+  }
 };
 
 /**
@@ -47,6 +48,7 @@ export interface IConfig {
   prompts?: PromptQuestion[];
   plugins?: IPlugin[];
   defaultProjectConfiguration?: IDefaultProjectConfiguration;
+  answers: Answers;
   displayName?: string;
 }
 
@@ -62,19 +64,20 @@ export interface IPluginContext extends Record<string, any> {
 export class TemplateConfiguration {
   private _prompts: PromptQuestion[];
   private _plugins: IPlugin[];
+  private _answers?: Answers;
   private _defaultProjectConfiguration: IDefaultProjectConfiguration;
   public displayName: string;
 
   private constructor(template: string) {
     const templateFolder: string = getTemplateFolder(template);
-    const result: LilconfigResult = lilconfigSync("init", {
+    const result: LilconfigResult = lilconfigSync('init', {
       searchPlaces,
-      loaders,
+      loaders
     }).search(templateFolder);
     this._prompts = [];
     this._plugins = [];
     this._defaultProjectConfiguration = {};
-    this.displayName = "";
+    this.displayName = '';
     if (result && result.config) {
       if (result.config.prompts) {
         this._prompts = result.config.prompts;
@@ -83,21 +86,19 @@ export class TemplateConfiguration {
         this._plugins = result.config.plugins;
       }
       if (result.config.defaultProjectConfiguration) {
-        this._defaultProjectConfiguration =
-          result.config.defaultProjectConfiguration;
+        this._defaultProjectConfiguration = result.config.defaultProjectConfiguration;
+      }
+      if (result.config.answers) {
+        this._answers = result.config.answers;
       }
       if (result.config.displayName) {
         this.displayName = result.config.displayName;
       }
     }
   }
-  public static async loadFromTemplate(
-    template: string
-  ): Promise<TemplateConfiguration> {
+  public static async loadFromTemplate(template: string): Promise<TemplateConfiguration> {
     if (!template) {
-      throw new Error(
-        "template is required when loading template configuration"
-      );
+      throw new Error('template is required when loading template configuration');
     }
     return new TemplateConfiguration(template);
   }
@@ -112,5 +113,8 @@ export class TemplateConfiguration {
 
   public get defaultProjectConfiguration(): IDefaultProjectConfiguration {
     return this._defaultProjectConfiguration;
+  }
+  public get answers(): Answers | undefined {
+    return this._answers;
   }
 }

--- a/rush-plugins/rush-init-project-plugin/src/plopfile.ts
+++ b/rush-plugins/rush-init-project-plugin/src/plopfile.ts
@@ -201,6 +201,17 @@ export default function (plop: NodePlopAPI, plopCfg: PlopCfg & ICliParams): void
         // when template decided, load template configuration
         if (currentPrompt?.name === 'template') {
           await loadTemplateConfiguration(promptQueue, currentAnswers.template!);
+
+          // answers from cli are prior to answers from template
+          // init answers
+          const promptQueueNames: Array<string | undefined> = promptQueue.map((x) => x.name);
+          allAnswers = pickBy(
+            {
+              ...(templateConfiguration?.answers ?? {}),
+              allAnswers
+            },
+            (v, k) => promptQueueNames.includes(k)
+          );
         }
 
         // merge answers


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [x] Reason for adding this feature
- [x] How to use
- [x] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary
For some queries‘ answers are unchanged， we want to skip they in specific template.

### Detail
Add answers field to template `init.config.js`.

e.g.
```
export default {
    prompts: [],
    plugins: [],
    defaultProjectConfiguration: {
      tags: ['tested-with-rush'],
      splitWorkspace: true
    },
    answers: {
      shouldRunRushUpdate: false
    },
    displayName: '[CSR SPA] @ttfe/webpack5',};
}
```

### How to test it
