### PR TITLE
Fix/template load run twice

### DIFF
--- a/common/changes/rush-init-project-plugin/fix-template-load-run-twice_2023-03-16-08-21.json
+++ b/common/changes/rush-init-project-plugin/fix-template-load-run-twice_2023-03-16-08-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-init-project-plugin",
+      "comment": "remove duplicate loadTemplateConfiguration",
+      "type": "patch"
+    }
+  ],
+  "packageName": "rush-init-project-plugin"
+}

--- a/rush-plugins/rush-init-project-plugin/src/plopfile.ts
+++ b/rush-plugins/rush-init-project-plugin/src/plopfile.ts
@@ -165,12 +165,8 @@ export default function (plop: NodePlopAPI, plopCfg: PlopCfg & ICliParams): void
 
       const promptQueue: PromptQuestion[] = defaultPrompts.slice();
 
+      // combine predefined answer
       if (pluginContext.cliAnswer) {
-        // if some answers are provided externally, use them instead of prompting.
-        // if template is provided externally, load template configuration.
-        if (pluginContext.cliAnswer?.template) {
-          await loadTemplateConfiguration(promptQueue, pluginContext.cliAnswer.template);
-        }
         const promptQueueNames: Array<string | undefined> = promptQueue.map((x) => x.name);
         allAnswers = pickBy(pluginContext.cliAnswer, (v, k) => promptQueueNames.includes(k));
       }
@@ -193,7 +189,7 @@ export default function (plop: NodePlopAPI, plopCfg: PlopCfg & ICliParams): void
         // https://github.com/SBoudrias/Inquirer.js#methods
         const currentAnswers: Partial<IExtendedAnswers> = await inquirer.prompt([currentPrompt], allAnswers);
 
-        // when template decided, load template configuration
+        // when template decided and not provide by defined answer, load template configuration
         if (currentPrompt?.name === 'template') {
           await loadTemplateConfiguration(promptQueue, currentAnswers.template!);
         }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary
template plugins will run twice because of  load template twice when use predefined template answer

### Detail

### How to test it
